### PR TITLE
Update RPC endpoint to reference omniflix

### DIFF
--- a/src/services/Keplr/KeplrConnection.js
+++ b/src/services/Keplr/KeplrConnection.js
@@ -115,7 +115,7 @@ export default {
 
     console.log('hasChain');
 
-    this.keplr_api_url = "https://rpc.juno.giansalex.dev";
+    this.keplr_api_url = "https://rpc.juno.omniflix.co";
     this.offlineSigner = window.getOfflineSigner(chainId);
     this.address = (await this.offlineSigner.getAccounts())[0].address;
     this.client = await SigningCosmWasmClient.connectWithSigner(this.keplr_api_url, this.offlineSigner);


### PR DESCRIPTION
Enable wallet connection and transactions as tested on: https://junomint.ezstaking.io/

Existing RPC endpoint throws error in chrome:
POST https://rpc.juno.giansalex.dev/ net::ERR_NAME_NOT_RESOLVED

New RPC endpoint results in successful CW20 creation